### PR TITLE
Creating an empty package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+# don't ever lint node_modules
+node_modules
+# don't lint build output (make sure it's set to your correct build folder name)
+dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+node_modules/
+dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+*.json
+*.md
+*.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "giddy",
+  "version": "0.1.0",
+  "description": "A small library to generate GUIDs",
+  "main": "./dist/bundle.js",
+  "scripts": {
+    "build": "npx webpack",
+    "lint": "npx eslint . --ext .ts",
+    "prettier": "npx prettier --write .",
+    "bundle": "npm run build && npm run lint && npm run prettier"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adhithyan15/giddy.git"
+  },
+  "keywords": [
+    "Graph"
+  ],
+  "author": "Adhithya Rajasekaran",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/adhithyan15/giddy/issues"
+  },
+  "homepage": "https://github.com/adhithyan15/giddy#readme",
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.25.0",
+    "@typescript-eslint/parser": "^4.25.0",
+    "eslint": "^7.27.0",
+    "prettier": "2.3.0",
+    "ts-loader": "^9.2.2",
+    "typescript": "^4.2.4",
+    "webpack": "^5.37.1",
+    "webpack-cli": "^4.7.0"
+  }
+}

--- a/src/implementations/GuidGeneratorFactoryImpl.ts
+++ b/src/implementations/GuidGeneratorFactoryImpl.ts
@@ -1,0 +1,7 @@
+import { GuidGeneratorFactory } from "../interfaces/GuidGeneratorFactory";
+
+export class GuidGeneratorFactoryImpl implements GuidGeneratorFactory {
+    public generateGuid(): string {
+        return "";
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+import { GuidGeneratorFactory } from "./interfaces/GuidGeneratorFactory";
+import { GuidGeneratorFactoryImpl } from "./implementations/GuidGeneratorFactoryImpl";
+
+export function getGuidGeneratorFactory(): GuidGeneratorFactory {
+    return new GuidGeneratorFactoryImpl();
+}

--- a/src/interfaces/GuidGeneratorFactory.ts
+++ b/src/interfaces/GuidGeneratorFactory.ts
@@ -1,0 +1,3 @@
+export interface GuidGeneratorFactory {
+    generateGuid(): string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "allowJs": false,
+    "module": "es6",
+    "target": "ES5",
+    "incremental": true,
+    "sourceMap": true,
+    "noImplicitThis": true,
+    "strict": true
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.ts',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  mode: "production"
+};


### PR DESCRIPTION
Adding the shell of the package. It contains the `GuidGeneratorFactory` interface which will be used to generate guids. 